### PR TITLE
chore(issue-templates): auto-assign Bug/Feature issue types

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -1,5 +1,6 @@
 name: Bug report
 description: Report a bug for Command Code.
+type: Bug
 labels: []
 body:
     - type: markdown

--- a/.github/ISSUE_TEMPLATE/2.feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2.feature_request.yml
@@ -1,5 +1,6 @@
 name: Feature Request
 description: Propose a new feature for Command Code.
+type: Feature
 labels: []
 body:
     - type: markdown


### PR DESCRIPTION
## Summary

- Adds `type: Bug` to `.github/ISSUE_TEMPLATE/1.bug_report.yml`
- Adds `type: Feature` to `.github/ISSUE_TEMPLATE/2.feature_request.yml`

Issues filed through these templates will now be auto-tagged with the org-level Issue Type, so triage doesn't have to set it manually.

Both `Bug` and `Feature` types are already configured at the `CommandCodeAI` org level, so this just wires the templates to use them.

## Test plan

- [ ] After merge, open a test issue via the Bug report template — confirm the Issue Type is auto-set to `Bug`
- [ ] Open a test issue via the Feature request template — confirm the Issue Type is auto-set to `Feature`
- [ ] Close the test issues