### PR TITLE
feat: DeepSeek peak-hour pricing with pass-through plan metering

### DIFF
--- a/docs/deepseek-peak-pricing.md
+++ b/docs/deepseek-peak-pricing.md
@@ -1,0 +1,39 @@
+# DeepSeek peak-hour pricing
+
+DeepSeek replaces its flat API rates with a peak/off-peak schedule at
+**16:00 UTC on 2026-08-16** ([official pricing page](https://api-docs.deepseek.com/quick_start/pricing/)).
+
+## Schedule
+
+- **Peak windows (daily, UTC):** 01:00–04:00 and 06:00–10:00
+- **Off-peak:** all other hours
+- **Peak rates = 2× off-peak rates**
+- Before the cutover instant, the old flat rates apply around the clock —
+  including inside the future peak windows on Aug 16 itself.
+
+## Rates (USD per 1M tokens)
+
+| Model | Tier | Cache-hit input | Cache-miss input | Output |
+| --- | --- | --- | --- | --- |
+| deepseek-v4-flash | flat (pre-cutover) | $0.0028 | $0.14 | $0.28 |
+| deepseek-v4-flash | off-peak | $0.007 | $0.22 | $0.66 |
+| deepseek-v4-flash | peak | $0.014 | $0.44 | $1.32 |
+| deepseek-v4-pro | flat (pre-cutover) | $0.003625 | $0.435 | $0.87 |
+| deepseek-v4-pro | off-peak | $0.022 | $0.66 | $1.98 |
+| deepseek-v4-pro | peak | $0.044 | $1.32 | $3.96 |
+
+The retired `deepseek-chat` and `deepseek-reasoner` model IDs are accepted as
+aliases of `deepseek-v4-flash`.
+
+## How Command Code plans handle it
+
+Provider charges are computed dynamically (`src/pricing/deepseek.js`), but
+**Goat and Pro subscribers keep the same usage allowance at all hours**:
+
+- Plan allowances are metered at the time-independent base (off-peak) rates
+  via `getBaseRates()`, so a request consumes the same allowance at 07:00 UTC
+  as at 15:00 UTC.
+- The peak premium is absorbed by us and surfaced as `peakSurchargeUsd` in
+  `meterUsage()` (`src/pricing/plan-usage.js`) for internal cost accounting.
+- Pay-as-you-go usage is billed at the dynamic rate in force when the
+  request runs.

--- a/docs/deepseek-peak-pricing.md
+++ b/docs/deepseek-peak-pricing.md
@@ -27,13 +27,13 @@ aliases of `deepseek-v4-flash`.
 
 ## How Command Code plans handle it
 
-Provider charges are computed dynamically (`src/pricing/deepseek.js`), but
-**Goat and Pro subscribers keep the same usage allowance at all hours**:
+Provider charges are computed dynamically (`src/pricing/deepseek.js`) and the
+**peak premium is passed through to customers — we absorb nothing**:
 
-- Plan allowances are metered at the time-independent base (off-peak) rates
-  via `getBaseRates()`, so a request consumes the same allowance at 07:00 UTC
-  as at 15:00 UTC.
-- The peak premium is absorbed by us and surfaced as `peakSurchargeUsd` in
-  `meterUsage()` (`src/pricing/plan-usage.js`) for internal cost accounting.
-- Pay-as-you-go usage is billed at the dynamic rate in force when the
-  request runs.
+- Goat and Pro are treated identically: plan allowances are metered at the
+  dynamic rate in force when the request runs, so the same request consumes
+  2x the allowance during peak hours.
+- Pay-as-you-go usage is billed directly at the same dynamic rate.
+- `peakPremiumUsd` in `meterUsage()` (`src/pricing/plan-usage.js`) reports
+  the portion of each charge attributable to peak pricing, for receipts and
+  usage breakdowns.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "command-code",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Command Code — the coding agent that learns your coding taste.",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/src/pricing/deepseek.js
+++ b/src/pricing/deepseek.js
@@ -1,0 +1,175 @@
+/**
+ * DeepSeek model pricing, including the peak/off-peak schedule that takes
+ * effect on 2026-08-16 at 16:00 UTC.
+ *
+ * Source: https://api-docs.deepseek.com/quick_start/pricing/
+ *
+ * Peak windows (daily, UTC): 01:00–04:00 and 06:00–10:00.
+ * Peak rates are 2x the off-peak rates. Before the cutover instant the old
+ * flat rates apply around the clock.
+ *
+ * All rates are USD per 1 million tokens.
+ */
+
+/** Instant at which the peak/off-peak schedule replaces the flat rates. */
+export const PEAK_PRICING_EFFECTIVE_AT = new Date(Date.UTC(2026, 7, 16, 16, 0, 0));
+
+/** Daily peak windows in UTC. Each window covers [startHour, endHour). */
+export const PEAK_WINDOWS_UTC = Object.freeze([
+  Object.freeze({ startHour: 1, endHour: 4 }),
+  Object.freeze({ startHour: 6, endHour: 10 }),
+]);
+
+/** Peak rates are this multiple of the off-peak rates. */
+export const PEAK_MULTIPLIER = 2;
+
+/** Pricing tiers returned by getRates(). */
+export const PricingTier = Object.freeze({
+  /** Flat legacy pricing, before the 2026-08-16 16:00 UTC cutover. */
+  FLAT: 'flat',
+  OFF_PEAK: 'off-peak',
+  PEAK: 'peak',
+});
+
+/**
+ * Legacy aliases still accepted by the API surface. DeepSeek retired
+ * deepseek-chat / deepseek-reasoner as model IDs on 2026-07-24; both were
+ * aliases of deepseek-v4-flash (non-thinking / thinking modes).
+ */
+const MODEL_ALIASES = Object.freeze({
+  'deepseek-chat': 'deepseek-v4-flash',
+  'deepseek-reasoner': 'deepseek-v4-flash',
+});
+
+/**
+ * USD per 1M tokens.
+ * - flat: rates in effect until PEAK_PRICING_EFFECTIVE_AT.
+ * - offPeak: rates outside the peak windows from the cutover onward.
+ *   Peak rates are always offPeak * PEAK_MULTIPLIER.
+ */
+const MODEL_RATES = Object.freeze({
+  'deepseek-v4-flash': Object.freeze({
+    flat: Object.freeze({ cacheHitInput: 0.0028, cacheMissInput: 0.14, output: 0.28 }),
+    offPeak: Object.freeze({ cacheHitInput: 0.007, cacheMissInput: 0.22, output: 0.66 }),
+  }),
+  'deepseek-v4-pro': Object.freeze({
+    flat: Object.freeze({ cacheHitInput: 0.003625, cacheMissInput: 0.435, output: 0.87 }),
+    offPeak: Object.freeze({ cacheHitInput: 0.022, cacheMissInput: 0.66, output: 1.98 }),
+  }),
+});
+
+/** Canonical model IDs with pricing data. */
+export const PRICED_MODELS = Object.freeze(Object.keys(MODEL_RATES));
+
+/**
+ * Resolve a model name (including legacy aliases) to its canonical ID.
+ * Throws on models with no pricing data so charges never silently
+ * default to zero.
+ */
+export function resolveModel(model) {
+  const canonical = MODEL_ALIASES[model] ?? model;
+  if (!Object.hasOwn(MODEL_RATES, canonical)) {
+    throw new RangeError(`No DeepSeek pricing data for model "${model}"`);
+  }
+  return canonical;
+}
+
+/**
+ * Whether peak pricing applies at the given instant. Always false before
+ * the schedule's effective date.
+ */
+export function isPeakTime(at) {
+  const ts = toDate(at);
+  if (ts < PEAK_PRICING_EFFECTIVE_AT) return false;
+  const hour = ts.getUTCHours();
+  return PEAK_WINDOWS_UTC.some((w) => hour >= w.startHour && hour < w.endHour);
+}
+
+/**
+ * Rates in force for a model at an instant.
+ *
+ * @returns {{ tier: string, rates: { cacheHitInput: number, cacheMissInput: number, output: number } }}
+ */
+export function getRates(model, at) {
+  const canonical = resolveModel(model);
+  const ts = toDate(at);
+  const { flat, offPeak } = MODEL_RATES[canonical];
+
+  if (ts < PEAK_PRICING_EFFECTIVE_AT) {
+    return { tier: PricingTier.FLAT, rates: flat };
+  }
+  if (isPeakTime(ts)) {
+    return {
+      tier: PricingTier.PEAK,
+      rates: scaleRates(offPeak, PEAK_MULTIPLIER),
+    };
+  }
+  return { tier: PricingTier.OFF_PEAK, rates: offPeak };
+}
+
+/**
+ * Rates used for plan-allowance metering: time-of-day independent, so a
+ * request consumes the same allowance whether it runs at peak or not.
+ * Flat rates before the cutover, off-peak rates after it.
+ */
+export function getBaseRates(model, at) {
+  const canonical = resolveModel(model);
+  const ts = toDate(at);
+  const { flat, offPeak } = MODEL_RATES[canonical];
+  return ts < PEAK_PRICING_EFFECTIVE_AT
+    ? { tier: PricingTier.FLAT, rates: flat }
+    : { tier: PricingTier.OFF_PEAK, rates: offPeak };
+}
+
+/**
+ * Cost in USD of a single usage record at the rates in force at `at`.
+ *
+ * @param {string} model
+ * @param {{ cacheHitInputTokens?: number, cacheMissInputTokens?: number, outputTokens?: number }} usage
+ * @param {Date | number | string} at
+ * @returns {{ tier: string, costUsd: number, rates: object }}
+ */
+export function calculateCharge(model, usage, at) {
+  const { tier, rates } = getRates(model, at);
+  return { tier, rates, costUsd: costUsd(usage, rates) };
+}
+
+/** Cost in USD for a usage record at a given per-1M-token rate card. */
+export function costUsd(usage, rates) {
+  const cacheHit = tokenCount(usage.cacheHitInputTokens, 'cacheHitInputTokens');
+  const cacheMiss = tokenCount(usage.cacheMissInputTokens, 'cacheMissInputTokens');
+  const output = tokenCount(usage.outputTokens, 'outputTokens');
+  const raw =
+    (cacheHit * rates.cacheHitInput + cacheMiss * rates.cacheMissInput + output * rates.output) /
+    1_000_000;
+  return roundUsd(raw);
+}
+
+/** Round to micro-dollar precision to keep sums stable. */
+export function roundUsd(value) {
+  return Math.round(value * 1e6) / 1e6;
+}
+
+function scaleRates(rates, factor) {
+  return {
+    cacheHitInput: rates.cacheHitInput * factor,
+    cacheMissInput: rates.cacheMissInput * factor,
+    output: rates.output * factor,
+  };
+}
+
+function tokenCount(value, field) {
+  if (value === undefined || value === null) return 0;
+  if (!Number.isFinite(value) || value < 0) {
+    throw new RangeError(`${field} must be a non-negative finite number, got ${value}`);
+  }
+  return value;
+}
+
+function toDate(at) {
+  const ts = at instanceof Date ? at : new Date(at);
+  if (Number.isNaN(ts.getTime())) {
+    throw new RangeError(`Invalid timestamp: ${at}`);
+  }
+  return ts;
+}

--- a/src/pricing/plan-usage.js
+++ b/src/pricing/plan-usage.js
@@ -1,0 +1,63 @@
+/**
+ * Plan-aware metering for DeepSeek charges under the peak/off-peak schedule.
+ *
+ * Product requirement: provider charges are priced dynamically during peak
+ * hours, but Goat and Pro subscribers keep the same usage allowance around
+ * the clock. We achieve that by always metering plan allowances at the
+ * time-of-day-independent base (off-peak) rates; the peak premium is
+ * absorbed by us and tracked separately as `peakSurchargeUsd` for internal
+ * cost accounting. Pay-as-you-go usage is billed at the dynamic rate in
+ * force when the request runs.
+ */
+
+import { calculateCharge, costUsd, getBaseRates, roundUsd } from './deepseek.js';
+
+export const PLANS = Object.freeze({
+  goat: Object.freeze({ id: 'goat', name: 'Goat', absorbsPeakSurcharge: true }),
+  pro: Object.freeze({ id: 'pro', name: 'Pro', absorbsPeakSurcharge: true }),
+  payg: Object.freeze({ id: 'payg', name: 'Pay as you go', absorbsPeakSurcharge: false }),
+});
+
+/**
+ * Meter one usage record against a plan.
+ *
+ * @param {{ plan: string, model: string, usage: object, at: Date | number | string }} params
+ * @returns {{
+ *   plan: string,
+ *   tier: string,                    // pricing tier in force when the request ran
+ *   providerCostUsd: number,         // what DeepSeek charges us (dynamic)
+ *   planUsageUsd: number,            // what we deduct from the user's allowance
+ *   billedUsd: number,               // what the user pays on top of the plan (PAYG only)
+ *   peakSurchargeUsd: number,        // peak premium we absorb for plan users
+ * }}
+ */
+export function meterUsage({ plan, model, usage, at }) {
+  const planDef = PLANS[plan];
+  if (!planDef) {
+    throw new RangeError(`Unknown plan "${plan}"`);
+  }
+
+  const provider = calculateCharge(model, usage, at);
+  const base = getBaseRates(model, at);
+  const baseCostUsd = costUsd(usage, base.rates);
+
+  if (planDef.absorbsPeakSurcharge) {
+    return {
+      plan: planDef.id,
+      tier: provider.tier,
+      providerCostUsd: provider.costUsd,
+      planUsageUsd: baseCostUsd,
+      billedUsd: 0,
+      peakSurchargeUsd: roundUsd(provider.costUsd - baseCostUsd),
+    };
+  }
+
+  return {
+    plan: planDef.id,
+    tier: provider.tier,
+    providerCostUsd: provider.costUsd,
+    planUsageUsd: 0,
+    billedUsd: provider.costUsd,
+    peakSurchargeUsd: 0,
+  };
+}

--- a/src/pricing/plan-usage.js
+++ b/src/pricing/plan-usage.js
@@ -1,21 +1,21 @@
 /**
  * Plan-aware metering for DeepSeek charges under the peak/off-peak schedule.
  *
- * Product requirement: provider charges are priced dynamically during peak
- * hours, but Goat and Pro subscribers keep the same usage allowance around
- * the clock. We achieve that by always metering plan allowances at the
- * time-of-day-independent base (off-peak) rates; the peak premium is
- * absorbed by us and tracked separately as `peakSurchargeUsd` for internal
- * cost accounting. Pay-as-you-go usage is billed at the dynamic rate in
- * force when the request runs.
+ * Product requirement: the peak premium is passed through to customers, not
+ * absorbed by us. Goat and Pro are treated identically: plan allowances are
+ * metered at the dynamic rate in force when the request runs, so the same
+ * request consumes twice the allowance during peak hours (peak = 2x
+ * off-peak). Pay-as-you-go usage is billed directly at the same dynamic
+ * rate. `peakPremiumUsd` reports the portion of the charge attributable to
+ * peak pricing, for receipts and usage breakdowns.
  */
 
 import { calculateCharge, costUsd, getBaseRates, roundUsd } from './deepseek.js';
 
 export const PLANS = Object.freeze({
-  goat: Object.freeze({ id: 'goat', name: 'Goat', absorbsPeakSurcharge: true }),
-  pro: Object.freeze({ id: 'pro', name: 'Pro', absorbsPeakSurcharge: true }),
-  payg: Object.freeze({ id: 'payg', name: 'Pay as you go', absorbsPeakSurcharge: false }),
+  goat: Object.freeze({ id: 'goat', name: 'Goat', billing: 'allowance' }),
+  pro: Object.freeze({ id: 'pro', name: 'Pro', billing: 'allowance' }),
+  payg: Object.freeze({ id: 'payg', name: 'Pay as you go', billing: 'direct' }),
 });
 
 /**
@@ -24,11 +24,11 @@ export const PLANS = Object.freeze({
  * @param {{ plan: string, model: string, usage: object, at: Date | number | string }} params
  * @returns {{
  *   plan: string,
- *   tier: string,                    // pricing tier in force when the request ran
- *   providerCostUsd: number,         // what DeepSeek charges us (dynamic)
- *   planUsageUsd: number,            // what we deduct from the user's allowance
- *   billedUsd: number,               // what the user pays on top of the plan (PAYG only)
- *   peakSurchargeUsd: number,        // peak premium we absorb for plan users
+ *   tier: string,            // pricing tier in force when the request ran
+ *   providerCostUsd: number, // what DeepSeek charges us (dynamic)
+ *   planUsageUsd: number,    // deducted from the plan allowance (dynamic; 0 for direct billing)
+ *   billedUsd: number,       // charged directly to the customer (0 for allowance plans)
+ *   peakPremiumUsd: number,  // portion of the charge attributable to peak pricing
  * }}
  */
 export function meterUsage({ plan, model, usage, at }) {
@@ -39,25 +39,14 @@ export function meterUsage({ plan, model, usage, at }) {
 
   const provider = calculateCharge(model, usage, at);
   const base = getBaseRates(model, at);
-  const baseCostUsd = costUsd(usage, base.rates);
-
-  if (planDef.absorbsPeakSurcharge) {
-    return {
-      plan: planDef.id,
-      tier: provider.tier,
-      providerCostUsd: provider.costUsd,
-      planUsageUsd: baseCostUsd,
-      billedUsd: 0,
-      peakSurchargeUsd: roundUsd(provider.costUsd - baseCostUsd),
-    };
-  }
+  const peakPremiumUsd = roundUsd(provider.costUsd - costUsd(usage, base.rates));
 
   return {
     plan: planDef.id,
     tier: provider.tier,
     providerCostUsd: provider.costUsd,
-    planUsageUsd: 0,
-    billedUsd: provider.costUsd,
-    peakSurchargeUsd: 0,
+    planUsageUsd: planDef.billing === 'allowance' ? provider.costUsd : 0,
+    billedUsd: planDef.billing === 'direct' ? provider.costUsd : 0,
+    peakPremiumUsd,
   };
 }

--- a/test/pricing/deepseek.test.js
+++ b/test/pricing/deepseek.test.js
@@ -1,0 +1,130 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  PEAK_PRICING_EFFECTIVE_AT,
+  PEAK_WINDOWS_UTC,
+  PricingTier,
+  calculateCharge,
+  getBaseRates,
+  getRates,
+  isPeakTime,
+  resolveModel,
+} from '../../src/pricing/deepseek.js';
+
+const utc = (y, mo, d, h, mi = 0) => new Date(Date.UTC(y, mo - 1, d, h, mi));
+
+// A day safely after the cutover.
+const AFTER = (h, mi = 0) => utc(2026, 8, 20, h, mi);
+
+test('cutover instant is 2026-08-16 16:00 UTC', () => {
+  assert.equal(PEAK_PRICING_EFFECTIVE_AT.toISOString(), '2026-08-16T16:00:00.000Z');
+});
+
+test('peak windows are 01:00–04:00 and 06:00–10:00 UTC', () => {
+  assert.deepEqual(
+    PEAK_WINDOWS_UTC.map((w) => [w.startHour, w.endHour]),
+    [
+      [1, 4],
+      [6, 10],
+    ],
+  );
+});
+
+test('isPeakTime respects window boundaries (half-open intervals)', () => {
+  assert.equal(isPeakTime(AFTER(0, 59)), false);
+  assert.equal(isPeakTime(AFTER(1, 0)), true);
+  assert.equal(isPeakTime(AFTER(3, 59)), true);
+  assert.equal(isPeakTime(AFTER(4, 0)), false);
+  assert.equal(isPeakTime(AFTER(5, 59)), false);
+  assert.equal(isPeakTime(AFTER(6, 0)), true);
+  assert.equal(isPeakTime(AFTER(9, 59)), true);
+  assert.equal(isPeakTime(AFTER(10, 0)), false);
+  assert.equal(isPeakTime(AFTER(16, 30)), false);
+});
+
+test('no peak pricing before the cutover, even inside a peak window', () => {
+  // 02:00 UTC on Aug 16 is inside a peak window but before the 16:00 cutover.
+  assert.equal(isPeakTime(utc(2026, 8, 16, 2)), false);
+  const { tier, rates } = getRates('deepseek-v4-flash', utc(2026, 8, 16, 2));
+  assert.equal(tier, PricingTier.FLAT);
+  assert.deepEqual(rates, { cacheHitInput: 0.0028, cacheMissInput: 0.14, output: 0.28 });
+});
+
+test('off-peak rates apply right after the cutover (outside peak windows)', () => {
+  const { tier, rates } = getRates('deepseek-v4-flash', utc(2026, 8, 16, 17));
+  assert.equal(tier, PricingTier.OFF_PEAK);
+  assert.deepEqual(rates, { cacheHitInput: 0.007, cacheMissInput: 0.22, output: 0.66 });
+});
+
+test('peak rates are exactly 2x off-peak for v4-flash', () => {
+  const { tier, rates } = getRates('deepseek-v4-flash', AFTER(7));
+  assert.equal(tier, PricingTier.PEAK);
+  assert.deepEqual(rates, { cacheHitInput: 0.014, cacheMissInput: 0.44, output: 1.32 });
+});
+
+test('peak rates are exactly 2x off-peak for v4-pro', () => {
+  const { tier, rates } = getRates('deepseek-v4-pro', AFTER(2));
+  assert.equal(tier, PricingTier.PEAK);
+  assert.deepEqual(rates, { cacheHitInput: 0.044, cacheMissInput: 1.32, output: 3.96 });
+});
+
+test('legacy flat rates for v4-pro before cutover', () => {
+  const { tier, rates } = getRates('deepseek-v4-pro', utc(2026, 8, 10, 12));
+  assert.equal(tier, PricingTier.FLAT);
+  assert.deepEqual(rates, { cacheHitInput: 0.003625, cacheMissInput: 0.435, output: 0.87 });
+});
+
+test('legacy aliases resolve to v4-flash', () => {
+  assert.equal(resolveModel('deepseek-chat'), 'deepseek-v4-flash');
+  assert.equal(resolveModel('deepseek-reasoner'), 'deepseek-v4-flash');
+  assert.deepEqual(getRates('deepseek-chat', AFTER(12)), getRates('deepseek-v4-flash', AFTER(12)));
+});
+
+test('unknown models throw instead of pricing at zero', () => {
+  assert.throws(() => resolveModel('deepseek-v9-mega'), RangeError);
+  assert.throws(() => getRates('gpt-4o', AFTER(12)), RangeError);
+});
+
+test('calculateCharge: off-peak v4-flash cost math', () => {
+  const usage = { cacheHitInputTokens: 1_000_000, cacheMissInputTokens: 1_000_000, outputTokens: 1_000_000 };
+  const { tier, costUsd } = calculateCharge('deepseek-v4-flash', usage, AFTER(12));
+  assert.equal(tier, PricingTier.OFF_PEAK);
+  assert.equal(costUsd, 0.007 + 0.22 + 0.66);
+});
+
+test('calculateCharge: peak doubles the cost of the same request', () => {
+  const usage = { cacheHitInputTokens: 250_000, cacheMissInputTokens: 500_000, outputTokens: 100_000 };
+  const offPeak = calculateCharge('deepseek-v4-pro', usage, AFTER(12));
+  const peak = calculateCharge('deepseek-v4-pro', usage, AFTER(8));
+  assert.equal(peak.costUsd, offPeak.costUsd * 2);
+});
+
+test('calculateCharge treats missing token fields as zero', () => {
+  const { costUsd } = calculateCharge('deepseek-v4-flash', { outputTokens: 2_000_000 }, AFTER(12));
+  assert.equal(costUsd, 1.32);
+});
+
+test('negative or non-finite token counts throw', () => {
+  assert.throws(
+    () => calculateCharge('deepseek-v4-flash', { outputTokens: -1 }, AFTER(12)),
+    RangeError,
+  );
+  assert.throws(
+    () => calculateCharge('deepseek-v4-flash', { outputTokens: Number.NaN }, AFTER(12)),
+    RangeError,
+  );
+});
+
+test('invalid timestamps throw', () => {
+  assert.throws(() => getRates('deepseek-v4-flash', 'not-a-date'), RangeError);
+});
+
+test('getBaseRates never returns peak pricing', () => {
+  const duringPeak = getBaseRates('deepseek-v4-pro', AFTER(2));
+  assert.equal(duringPeak.tier, PricingTier.OFF_PEAK);
+  assert.deepEqual(duringPeak.rates, { cacheHitInput: 0.022, cacheMissInput: 0.66, output: 1.98 });
+
+  const beforeCutover = getBaseRates('deepseek-v4-pro', utc(2026, 8, 1, 2));
+  assert.equal(beforeCutover.tier, PricingTier.FLAT);
+});

--- a/test/pricing/plan-usage.test.js
+++ b/test/pricing/plan-usage.test.js
@@ -1,0 +1,71 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { PLANS, meterUsage } from '../../src/pricing/plan-usage.js';
+import { PricingTier } from '../../src/pricing/deepseek.js';
+
+const utc = (h, mi = 0) => new Date(Date.UTC(2026, 7, 20, h, mi));
+
+const USAGE = {
+  cacheHitInputTokens: 400_000,
+  cacheMissInputTokens: 300_000,
+  outputTokens: 200_000,
+};
+
+test('goat and pro consume identical allowance at peak and off-peak', () => {
+  for (const plan of ['goat', 'pro']) {
+    const offPeak = meterUsage({ plan, model: 'deepseek-v4-flash', usage: USAGE, at: utc(12) });
+    const peak = meterUsage({ plan, model: 'deepseek-v4-flash', usage: USAGE, at: utc(7) });
+
+    assert.equal(offPeak.tier, PricingTier.OFF_PEAK);
+    assert.equal(peak.tier, PricingTier.PEAK);
+    // Same usage deduction regardless of time of day.
+    assert.equal(peak.planUsageUsd, offPeak.planUsageUsd);
+    // Plan users are never billed extra for peak.
+    assert.equal(peak.billedUsd, 0);
+    assert.equal(offPeak.billedUsd, 0);
+  }
+});
+
+test('peak surcharge is absorbed and equals the provider premium', () => {
+  const peak = meterUsage({ plan: 'goat', model: 'deepseek-v4-pro', usage: USAGE, at: utc(2) });
+  assert.equal(peak.providerCostUsd, peak.planUsageUsd * 2);
+  assert.equal(peak.peakSurchargeUsd, peak.providerCostUsd - peak.planUsageUsd);
+});
+
+test('no surcharge is recorded off-peak', () => {
+  const offPeak = meterUsage({ plan: 'pro', model: 'deepseek-v4-pro', usage: USAGE, at: utc(14) });
+  assert.equal(offPeak.peakSurchargeUsd, 0);
+  assert.equal(offPeak.providerCostUsd, offPeak.planUsageUsd);
+});
+
+test('pay-as-you-go pays the dynamic peak price directly', () => {
+  const peak = meterUsage({ plan: 'payg', model: 'deepseek-v4-flash', usage: USAGE, at: utc(8) });
+  const offPeak = meterUsage({ plan: 'payg', model: 'deepseek-v4-flash', usage: USAGE, at: utc(12) });
+
+  assert.equal(peak.billedUsd, peak.providerCostUsd);
+  assert.equal(peak.billedUsd, offPeak.billedUsd * 2);
+  assert.equal(peak.planUsageUsd, 0);
+  assert.equal(peak.peakSurchargeUsd, 0);
+});
+
+test('plan metering before the cutover uses the legacy flat rates', () => {
+  const at = new Date(Date.UTC(2026, 7, 16, 2)); // pre-cutover, inside future peak window
+  const result = meterUsage({ plan: 'goat', model: 'deepseek-v4-flash', usage: USAGE, at });
+  assert.equal(result.tier, PricingTier.FLAT);
+  assert.equal(result.peakSurchargeUsd, 0);
+  assert.equal(result.providerCostUsd, result.planUsageUsd);
+});
+
+test('unknown plans throw', () => {
+  assert.throws(
+    () => meterUsage({ plan: 'free', model: 'deepseek-v4-flash', usage: USAGE, at: utc(12) }),
+    RangeError,
+  );
+});
+
+test('plan registry flags who absorbs the surcharge', () => {
+  assert.equal(PLANS.goat.absorbsPeakSurcharge, true);
+  assert.equal(PLANS.pro.absorbsPeakSurcharge, true);
+  assert.equal(PLANS.payg.absorbsPeakSurcharge, false);
+});

--- a/test/pricing/plan-usage.test.js
+++ b/test/pricing/plan-usage.test.js
@@ -12,31 +12,40 @@ const USAGE = {
   outputTokens: 200_000,
 };
 
-test('goat and pro consume identical allowance at peak and off-peak', () => {
+test('goat and pro allowances deduct at the dynamic rate: peak burns 2x', () => {
   for (const plan of ['goat', 'pro']) {
     const offPeak = meterUsage({ plan, model: 'deepseek-v4-flash', usage: USAGE, at: utc(12) });
     const peak = meterUsage({ plan, model: 'deepseek-v4-flash', usage: USAGE, at: utc(7) });
 
     assert.equal(offPeak.tier, PricingTier.OFF_PEAK);
     assert.equal(peak.tier, PricingTier.PEAK);
-    // Same usage deduction regardless of time of day.
-    assert.equal(peak.planUsageUsd, offPeak.planUsageUsd);
-    // Plan users are never billed extra for peak.
+    // Peak premium is passed through: the same request costs double allowance.
+    assert.equal(peak.planUsageUsd, offPeak.planUsageUsd * 2);
+    // Allowance plans are never billed directly.
     assert.equal(peak.billedUsd, 0);
     assert.equal(offPeak.billedUsd, 0);
   }
 });
 
-test('peak surcharge is absorbed and equals the provider premium', () => {
-  const peak = meterUsage({ plan: 'goat', model: 'deepseek-v4-pro', usage: USAGE, at: utc(2) });
-  assert.equal(peak.providerCostUsd, peak.planUsageUsd * 2);
-  assert.equal(peak.peakSurchargeUsd, peak.providerCostUsd - peak.planUsageUsd);
+test('goat and pro are treated identically', () => {
+  const goat = meterUsage({ plan: 'goat', model: 'deepseek-v4-pro', usage: USAGE, at: utc(2) });
+  const pro = meterUsage({ plan: 'pro', model: 'deepseek-v4-pro', usage: USAGE, at: utc(2) });
+  assert.deepEqual({ ...goat, plan: null }, { ...pro, plan: null });
 });
 
-test('no surcharge is recorded off-peak', () => {
+test('nothing is absorbed: allowance deduction always covers provider cost', () => {
+  for (const at of [utc(2), utc(7), utc(12), utc(23)]) {
+    const result = meterUsage({ plan: 'goat', model: 'deepseek-v4-pro', usage: USAGE, at });
+    assert.equal(result.planUsageUsd, result.providerCostUsd);
+  }
+});
+
+test('peak premium is reported as the peak-attributable portion of the charge', () => {
+  const peak = meterUsage({ plan: 'pro', model: 'deepseek-v4-pro', usage: USAGE, at: utc(2) });
+  assert.equal(peak.peakPremiumUsd, peak.providerCostUsd / 2);
+
   const offPeak = meterUsage({ plan: 'pro', model: 'deepseek-v4-pro', usage: USAGE, at: utc(14) });
-  assert.equal(offPeak.peakSurchargeUsd, 0);
-  assert.equal(offPeak.providerCostUsd, offPeak.planUsageUsd);
+  assert.equal(offPeak.peakPremiumUsd, 0);
 });
 
 test('pay-as-you-go pays the dynamic peak price directly', () => {
@@ -46,15 +55,14 @@ test('pay-as-you-go pays the dynamic peak price directly', () => {
   assert.equal(peak.billedUsd, peak.providerCostUsd);
   assert.equal(peak.billedUsd, offPeak.billedUsd * 2);
   assert.equal(peak.planUsageUsd, 0);
-  assert.equal(peak.peakSurchargeUsd, 0);
 });
 
 test('plan metering before the cutover uses the legacy flat rates', () => {
   const at = new Date(Date.UTC(2026, 7, 16, 2)); // pre-cutover, inside future peak window
   const result = meterUsage({ plan: 'goat', model: 'deepseek-v4-flash', usage: USAGE, at });
   assert.equal(result.tier, PricingTier.FLAT);
-  assert.equal(result.peakSurchargeUsd, 0);
-  assert.equal(result.providerCostUsd, result.planUsageUsd);
+  assert.equal(result.peakPremiumUsd, 0);
+  assert.equal(result.planUsageUsd, result.providerCostUsd);
 });
 
 test('unknown plans throw', () => {
@@ -64,8 +72,8 @@ test('unknown plans throw', () => {
   );
 });
 
-test('plan registry flags who absorbs the surcharge', () => {
-  assert.equal(PLANS.goat.absorbsPeakSurcharge, true);
-  assert.equal(PLANS.pro.absorbsPeakSurcharge, true);
-  assert.equal(PLANS.payg.absorbsPeakSurcharge, false);
+test('plan registry declares billing modes', () => {
+  assert.equal(PLANS.goat.billing, 'allowance');
+  assert.equal(PLANS.pro.billing, 'allowance');
+  assert.equal(PLANS.payg.billing, 'direct');
 });


### PR DESCRIPTION
## Description

DeepSeek replaces its flat API rates with a peak/off-peak schedule at **16:00 UTC on 2026-08-16** ([pricing page](https://api-docs.deepseek.com/quick_start/pricing/)). Peak windows are **01:00–04:00 and 06:00–10:00 UTC** daily, and peak rates are **2× the off-peak rates**.

This PR adds:

- **`src/pricing/deepseek.js`** — the full rate schedule for `deepseek-v4-flash` and `deepseek-v4-pro` with three tiers: `flat` (legacy rates before the cutover instant), `off-peak`, and `peak`. Includes peak-window detection (`isPeakTime`), dynamic rate lookup (`getRates`), cost calculation (`calculateCharge`), and resolution of the retired `deepseek-chat` / `deepseek-reasoner` aliases to `deepseek-v4-flash`. Unknown models throw instead of silently pricing at zero.
- **`src/pricing/plan-usage.js`** — plan-aware metering. **The peak premium is passed through to customers; we absorb nothing.** Goat and Pro are treated identically: allowances are metered at the dynamic rate in force at request time, so the same request consumes 2× the allowance during peak hours. Pay-as-you-go is billed directly at the same dynamic rate. `peakPremiumUsd` reports the peak-attributable portion of each charge for receipts and usage breakdowns.
- **`docs/deepseek-peak-pricing.md`** — the full rate table and the plan-handling design.

Rates per 1M tokens (cache-hit input / cache-miss input / output):

| Model | Off-peak | Peak (2×) |
| --- | --- | --- |
| deepseek-v4-flash | $0.007 / $0.22 / $0.66 | $0.014 / $0.44 / $1.32 |
| deepseek-v4-pro | $0.022 / $0.66 / $1.98 | $0.044 / $1.32 / $3.96 |

Edge case handled explicitly: before the 16:00 UTC cutover on Aug 16, legacy flat rates apply even inside the future peak windows (e.g. Aug 16 02:00 UTC is still flat-rate).

Note: press coverage states the cutover is 16:00 UTC (the task note said 16:09); the module uses 16:00. The v4-pro peak cache-miss ($1.32) and output ($3.96) figures are confirmed by coverage of the announcement; the v4-pro cache-hit figures are derived from the published blended multipliers and the 2× peak rule — worth a quick re-check against the official pricing page (blocked from this environment) before merge.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other

## PR Checklist

- [x] Ran all tests
- [ ] Changelog entry added (`packages/command/CHANGELOG.md` does not exist in this repo — skipped)
- [x] Tests added
- [x] Test instructions provided
- [x] Documentation updated
- [ ] PR assigned
- [ ] All reviewer comments addressed
- [x] No merge conflicts

## How to Test

1. Check out this branch: `git checkout claude/deepseek-peak-pricing-teb7my`.
2. Verify peak detection in a Node REPL (`node --input-type=module`):
   ```js
   import { isPeakTime, getRates } from './src/pricing/deepseek.js';
   isPeakTime(new Date('2026-08-20T07:30:00Z')); // true (06:00–10:00 window)
   isPeakTime(new Date('2026-08-20T12:00:00Z')); // false
   getRates('deepseek-v4-pro', new Date('2026-08-20T02:00:00Z')); // peak: 0.044 / 1.32 / 3.96
   ```
3. Verify the peak premium is passed through: call `meterUsage` from `src/pricing/plan-usage.js` with the same usage at `07:00Z` and `14:00Z` for plan `goat` or `pro` — `planUsageUsd` at peak must be exactly 2× the off-peak value and always equal `providerCostUsd` (nothing absorbed), with `peakPremiumUsd` showing the peak-attributable portion.
4. Verify the pre-cutover edge case: `getRates('deepseek-v4-flash', new Date('2026-08-16T02:00:00Z'))` returns the legacy flat tier ($0.0028 / $0.14 / $0.28) even though 02:00 is inside a peak window.
5. Run `npm test` to verify all tests pass.

## Test Results

```
✓ 24 tests passed | 0 failed | 0 skipped
Duration: 0.13s
```

## Visuals

N/A

## Documentation

`docs/deepseek-peak-pricing.md` (in this PR) documents the schedule, rate table, and plan handling.

**Ownership Reminder**: As the PR author, you own getting this merged. If reviewers miss pings, ping again. If conflicts arise, resolve them. If discussions are needed, start them on Slack. Be proactive!

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WBUCU28PV1tS7RTaei1ash